### PR TITLE
fix: reject reconnection objects that have expired

### DIFF
--- a/lib/adpConnection.js
+++ b/lib/adpConnection.js
@@ -144,7 +144,7 @@ function ADPConnection(connConfig) {
 	@returns {void}
 	*/
 	this.reconnect = function reconnect(reconnectionObject, cb) {
-		var isExpired = reconnectionObject.tokenExpiration < new Date();
+		var isExpired = new Date(reconnectionObject.tokenExpiration) < new Date();
 
 		if (!isExpired) {
 			// case 1, we have an access token that's not expired


### PR DESCRIPTION
The `tokenExpiration` property, that is considered during reconnections, is being set as a string. The `isExpired` check was modified to handle that.