### PR TITLE
Remove mongoose and request dependencies as they are not used

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "dependencies": {
     "adp-core": "^1.0.0",
     "config": "^1.19.0",
-    "mongoose": "^4.3.7",
     "node-uuid": "^1.4.7",
-    "request": "^2.67.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
These dependencies aren't used by code and trigger security vulnerability warnings because mongoose is so outdated.